### PR TITLE
Switched form decorator to 'Fieldset' to allow use of <legend> tags.

### DIFF
--- a/library/Twitter/Form.php
+++ b/library/Twitter/Form.php
@@ -15,7 +15,7 @@ class Twitter_Form extends Zend_Form
 
 		// Decorators for the form itself
 		$this->addDecorator("FormElements")
-			->addDecorator("HtmlTag", array("tag" => "fieldset"));
+			->addDecorator("Fieldset");
 
 		parent::__construct($options);
 	}


### PR DESCRIPTION
ZF supports a <fieldset> form decorator out-of-the-box, and using it enables the <legend> tags which Bootstrap supports for nicely formatted Form headers.
