### PR TITLE
Checking for textarea 'rows' attribute before setting default.

### DIFF
--- a/library/Twitter/Form.php
+++ b/library/Twitter/Form.php
@@ -141,7 +141,7 @@ class Twitter_Form extends Zend_Form
 			$element->setDecorators(array("ViewHelper"));
 		}
 		
-		if($element instanceof Zend_Form_Element_Textarea)
+		if($element instanceof Zend_Form_Element_Textarea && !$element->getAttrib('rows'))
 		{
 			$element->setAttrib('rows', '3');
 		}


### PR DESCRIPTION
A simple update to check for a defined 'rows' attribute on a textarea before setting to the default of 3. Otherwise it's impossible to specify the number of rows for the textarea.
